### PR TITLE
Add triple barrier conditions to DEMA SuperTrend ADX strategy

### DIFF
--- a/scripts/Dema_ST_ADX.py
+++ b/scripts/Dema_ST_ADX.py
@@ -9,7 +9,11 @@ from hummingbot.core.clock import Clock
 from hummingbot.core.data_type.common import MarketDict, PositionMode, PriceType, TradeType
 from hummingbot.data_feed.candles_feed.candles_factory import CandlesConfig
 from hummingbot.strategy.strategy_v2_base import StrategyV2Base, StrategyV2ConfigBase
-from hummingbot.strategy_v2.executors.position_executor.data_types import PositionExecutorConfig, TripleBarrierConfig
+from hummingbot.strategy_v2.executors.position_executor.data_types import (
+    PositionExecutorConfig,
+    TrailingStop,
+    TripleBarrierConfig,
+)
 from hummingbot.strategy_v2.models.executor_actions import CreateExecutorAction, StopExecutorAction
 
 
@@ -46,6 +50,7 @@ class DEMASTADXTokenConfig(StrategyV2ConfigBase):
 
     # Triple Barrier Configuration
     stop_loss_pct: Decimal = Field(default=Decimal("0.02"), gt=0)
+    trailing_stop_loss_pct: Decimal = Field(default=Decimal("0.01"), gt=0)
 
     # ADX Configuration
     adx_length: int = Field(default=14, gt=0)
@@ -169,13 +174,21 @@ class DEMASTADXTokenStrategy(StrategyV2Base):
 
                 if signal == 1 and len(active_longs) == 0:
                     # Configure triple barrier based on signal source
-                    if signal_source == 3:  # Condition 3: Use DEMA as TP
+                    if signal_source == 3:  # Condition 3: Use trailing stop that activates at DEMA
                         current_dema = self.current_dema[candles_pair]
-                        tp_pct = abs(current_dema - mid_price) / mid_price
+                        # For long: activation price is DEMA (where we expect price to reach)
+                        activation_price_pct = abs(current_dema - mid_price) / mid_price
+                        trailing_delta_pct = self.config.trailing_stop_loss_pct
                         sl_pct = self.config.stop_loss_pct
+
+                        trailing_stop = TrailingStop(
+                            activation_price=Decimal(str(activation_price_pct)),
+                            trailing_delta=Decimal(str(trailing_delta_pct))
+                        )
+
                         triple_barrier_config = TripleBarrierConfig(
-                            take_profit=Decimal(str(tp_pct)),
-                            stop_loss=Decimal(str(sl_pct))
+                            stop_loss=Decimal(str(sl_pct)),
+                            trailing_stop=trailing_stop
                         )
                     else:  # Conditions 1 & 2: Default config with all barriers disabled
                         triple_barrier_config = TripleBarrierConfig()
@@ -193,13 +206,21 @@ class DEMASTADXTokenStrategy(StrategyV2Base):
                         )))
                 elif signal == -1 and len(active_shorts) == 0:
                     # Configure triple barrier based on signal source
-                    if signal_source == 3:  # Condition 3: Use DEMA as TP
+                    if signal_source == 3:  # Condition 3: Use trailing stop that activates at DEMA
                         current_dema = self.current_dema[candles_pair]
-                        tp_pct = abs(mid_price - current_dema) / mid_price
+                        # For short: activation price is DEMA (where we expect price to reach)
+                        activation_price_pct = abs(mid_price - current_dema) / mid_price
+                        trailing_delta_pct = self.config.trailing_stop_loss_pct
                         sl_pct = self.config.stop_loss_pct
+
+                        trailing_stop = TrailingStop(
+                            activation_price=Decimal(str(activation_price_pct)),
+                            trailing_delta=Decimal(str(trailing_delta_pct))
+                        )
+
                         triple_barrier_config = TripleBarrierConfig(
-                            take_profit=Decimal(str(tp_pct)),
-                            stop_loss=Decimal(str(sl_pct))
+                            stop_loss=Decimal(str(sl_pct)),
+                            trailing_stop=trailing_stop
                         )
                     else:  # Conditions 1 & 2: Default config with all barriers disabled
                         triple_barrier_config = TripleBarrierConfig()
@@ -299,11 +320,22 @@ class DEMASTADXTokenStrategy(StrategyV2Base):
         if candles is None or candles.empty:
             return None
 
+        # Calculate indicators and update internal state
+        self._calculate_indicators(candles, trading_pair)
+
+        # Generate signal based on conditions
+        signal, signal_source = self._generate_signal(trading_pair)
+
+        # Store results and return
+        self.current_signal[trading_pair] = signal
+        self.signal_source[trading_pair] = signal_source
+        return signal
+
+    def _calculate_indicators(self, candles, trading_pair: str):
+        """Calculate and store all indicators for the given trading pair."""
         # Calculate indicators
         candles.ta.dema(length=self.config.dema_length, append=True)
         candles.ta.supertrend(length=self.config.supertrend_length, multiplier=self.config.supertrend_multiplier, append=True)
-
-        # Calculate ADX with directional indicators
         candles.ta.adx(length=self.config.adx_length, append=True)
 
         # Store previous ADX value before updating
@@ -336,15 +368,7 @@ class DEMASTADXTokenStrategy(StrategyV2Base):
             self.prev_market_condition[trading_pair] = "CHOPPY"  # Default to choppy
 
         # Determine market condition
-        adx_value = self.current_adx[trading_pair]
-        if adx_value < self.config.adx_threshold_choppy:
-            self.market_condition[trading_pair] = "CHOPPY"
-        elif adx_value < self.config.adx_threshold_trending:
-            self.market_condition[trading_pair] = "WEAK_TREND"
-        elif adx_value < self.config.adx_threshold_extreme:
-            self.market_condition[trading_pair] = "STRONG_TREND"
-        else:
-            self.market_condition[trading_pair] = "EXTREME_TREND"
+        self._update_market_condition(trading_pair)
 
         # Get current values
         self.current_price[trading_pair] = candles["close"].iloc[-1]
@@ -361,16 +385,25 @@ class DEMASTADXTokenStrategy(StrategyV2Base):
             self.prev_price[trading_pair] = self.current_price[trading_pair]
             self.prev_dema[trading_pair] = self.current_dema[trading_pair]
 
-        # Generate long and short conditions
+    def _update_market_condition(self, trading_pair: str):
+        """Update market condition based on ADX value."""
+        adx_value = self.current_adx[trading_pair]
+        if adx_value < self.config.adx_threshold_choppy:
+            self.market_condition[trading_pair] = "CHOPPY"
+        elif adx_value < self.config.adx_threshold_trending:
+            self.market_condition[trading_pair] = "WEAK_TREND"
+        elif adx_value < self.config.adx_threshold_extreme:
+            self.market_condition[trading_pair] = "STRONG_TREND"
+        else:
+            self.market_condition[trading_pair] = "EXTREME_TREND"
+
+    def _generate_signal(self, trading_pair: str) -> tuple[int, int]:
+        """Generate trading signal and return signal value and source."""
+        # Get current values
         current_price = self.current_price[trading_pair]
         current_dema = self.current_dema[trading_pair]
         current_supertrend_direction = self.current_supertrend_direction[trading_pair]
         prev_supertrend_direction = self.prev_supertrend_direction[trading_pair]
-
-        # self.logger().info(f"Current Price: {current_price}, Current DEMA: {current_dema}, Current SuperTrend Direction: {current_supertrend_direction}, Previous SuperTrend Direction: {prev_supertrend_direction}")
-
-        # Check if this is the first signal check after startup
-        is_startup_check = self.is_startup.get(trading_pair, False)
 
         # Get ADX values for conditions
         current_adx_val = self.current_adx[trading_pair]
@@ -378,10 +411,33 @@ class DEMASTADXTokenStrategy(StrategyV2Base):
         adx_crossed_threshold = prev_adx_val < self.config.adx_threshold_choppy <= current_adx_val
         adx_above_threshold = current_adx_val >= self.config.adx_threshold_choppy
 
+        # Check entry conditions
+        long_conditions = self._check_long_conditions(current_supertrend_direction, current_price, current_dema,
+                                                      adx_crossed_threshold, adx_above_threshold, prev_supertrend_direction)
+        short_conditions = self._check_short_conditions(current_supertrend_direction, current_price, current_dema,
+                                                        adx_crossed_threshold, adx_above_threshold, prev_supertrend_direction)
+
+        # Determine signal and source
+        signal, signal_source = self._determine_signal(long_conditions, short_conditions)
+
+        # Apply directional filter
+        signal, signal_source = self._apply_directional_filter(signal, signal_source, trading_pair)
+
+        # Reset startup flag after first signal check
+        is_startup_check = self.is_startup.get(trading_pair, False)
+        if is_startup_check:
+            self.is_startup[trading_pair] = False
+
+        return signal, signal_source
+
+    def _check_long_conditions(self, current_supertrend_direction, current_price, current_dema,
+                               adx_crossed_threshold, adx_above_threshold, prev_supertrend_direction) -> tuple[bool, bool, bool]:
+        """Check all long entry conditions."""
         # Long Entry Conditions:
         # 1. ADX crosses threshold with established bullish trend: ST already positive + Price > DEMA + ADX crosses above threshold
         # 2. ADX already established and ST flips: ADX above threshold + ST turns positive + Price > DEMA
-        # 3. NEW: ST green, ADX above threshold, price below DEMA (triple barrier with DEMA as TP)
+        # 3. NEW: ST green, ADX above threshold, price below DEMA (trailing stop activates at DEMA)
+
         long_condition_1 = (current_supertrend_direction == 1 and
                             current_price > current_dema and
                             adx_crossed_threshold)
@@ -391,25 +447,20 @@ class DEMASTADXTokenStrategy(StrategyV2Base):
                             current_supertrend_direction == 1 and
                             prev_supertrend_direction == -1)
 
-        # NOTE: not gonna use this, the price acts as a barrier not a support
-        # long_condition_3 = (prev_candle_close >= prev_dema and
-        #                     prev_prev_candle_close < prev_dema and
-        #                     adx_above_threshold and
-        #                     current_supertrend_direction == 1)
-
-        # New condition 3: ST green, ADX above threshold, price below DEMA
         long_condition_3 = (current_supertrend_direction == 1 and
                             adx_above_threshold and
                             current_price < current_dema)
 
-        # self.logger().info(f"========== {trading_pair} ==========")
-        # self.logger().info(f"Long Condition 1: {long_condition_1}")
-        # self.logger().info(f"Long Condition 2: {long_condition_2}")
-        # self.logger().info(f"Long Condition 3: {long_condition_3}")
+        return long_condition_1, long_condition_2, long_condition_3
+
+    def _check_short_conditions(self, current_supertrend_direction, current_price, current_dema,
+                                adx_crossed_threshold, adx_above_threshold, prev_supertrend_direction) -> tuple[bool, bool, bool]:
+        """Check all short entry conditions."""
         # Short Entry Conditions:
         # 1. ADX crosses threshold with established bearish trend: ST already negative + Price < DEMA + ADX crosses above threshold
         # 2. ADX already established and ST flips: ADX above threshold + ST turns negative + Price < DEMA
-        # 3. NEW: ST red, ADX above threshold, price above DEMA (triple barrier with DEMA as TP)
+        # 3. NEW: ST red, ADX above threshold, price above DEMA (trailing stop activates at DEMA)
+
         short_condition_1 = (current_supertrend_direction == -1 and
                              current_price < current_dema and
                              adx_crossed_threshold)
@@ -419,58 +470,43 @@ class DEMASTADXTokenStrategy(StrategyV2Base):
                              current_supertrend_direction == -1 and
                              prev_supertrend_direction == 1)
 
-        # NOTE: not gonna use this, the price acts as a barrier not a support
-        # short_condition_3 = (prev_candle_close <= prev_dema and
-        #                      prev_prev_candle_close >= prev_dema and
-        #                      adx_above_threshold and
-        #                      current_supertrend_direction == -1)
-
-        # New condition 3: ST red, ADX above threshold, price above DEMA
         short_condition_3 = (current_supertrend_direction == -1 and
                              adx_above_threshold and
                              current_price > current_dema)
-        # self.logger().info(f"Short Condition 1: {short_condition_1}")
-        # self.logger().info(f"Short Condition 2: {short_condition_2}")
-        # self.logger().info(f"Short Condition 3: {short_condition_3}")
-        # Determine signal and track which condition triggered it
-        signal_source = 0  # 0 = no signal, 1 = condition 1, 2 = condition 2, 3 = condition 3
-        if long_condition_1:
-            signal = 1
-            signal_source = 1
-        elif long_condition_2:
-            signal = 1
-            signal_source = 2
-        elif long_condition_3:
-            signal = 1
-            signal_source = 3
-        elif short_condition_1:
-            signal = -1
-            signal_source = 1
-        elif short_condition_2:
-            signal = -1
-            signal_source = 2
-        elif short_condition_3:
-            signal = -1
-            signal_source = 3
-        else:
-            signal = 0
 
-        # TO-DO (understand this part better)
+        return short_condition_1, short_condition_2, short_condition_3
+
+    def _determine_signal(self, long_conditions: tuple[bool, bool, bool],
+                          short_conditions: tuple[bool, bool, bool]) -> tuple[int, int]:
+        """Determine signal value and source based on conditions."""
+        long_condition_1, long_condition_2, long_condition_3 = long_conditions
+        short_condition_1, short_condition_2, short_condition_3 = short_conditions
+
+        # Determine signal and track which condition triggered it
+        if long_condition_1:
+            return 1, 1
+        elif long_condition_2:
+            return 1, 2
+        elif long_condition_3:
+            return 1, 3
+        elif short_condition_1:
+            return -1, 1
+        elif short_condition_2:
+            return -1, 2
+        elif short_condition_3:
+            return -1, 3
+        else:
+            return 0, 0
+
+    def _apply_directional_filter(self, signal: int, signal_source: int, trading_pair: str) -> tuple[int, int]:
+        """Apply directional filter to ensure directional agreement."""
         # Additional filter: Ensure directional agreement
         if signal == 1 and self.current_plus_di[trading_pair] <= self.current_minus_di[trading_pair]:
-            signal = 0  # Cancel long if -DI is stronger
-            signal_source = 0
+            return 0, 0  # Cancel long if -DI is stronger
         elif signal == -1 and self.current_minus_di[trading_pair] <= self.current_plus_di[trading_pair]:
-            signal = 0  # Cancel short if +DI is stronger
-            signal_source = 0
+            return 0, 0  # Cancel short if +DI is stronger
 
-        # Reset startup flag after first signal check
-        if is_startup_check:
-            self.is_startup[trading_pair] = False
-
-        self.current_signal[trading_pair] = signal
-        self.signal_source[trading_pair] = signal_source
-        return signal
+        return signal, signal_source
 
     def apply_initial_setting(self):
         if not self.account_config_set:

--- a/scripts/Dema_ST_ADX.py
+++ b/scripts/Dema_ST_ADX.py
@@ -153,7 +153,7 @@ class DEMASTADXTokenStrategy(StrategyV2Base):
             signal_source = self.signal_source.get(candles_pair, 0)
             active_longs, active_shorts = self.get_active_executors_by_side(self.config.exchange, trading_pair)
 
-            if signal is not None and signal != 0:  # Only process non-zero signals
+            if signal != 0:  # Only process non-zero signals
                 mid_price = self.market_data_provider.get_price_by_type(self.config.exchange,
                                                                         trading_pair,
                                                                         PriceType.MidPrice)

--- a/scripts/Dema_ST_ADX.py
+++ b/scripts/Dema_ST_ADX.py
@@ -49,7 +49,6 @@ class DEMASTADXTokenConfig(StrategyV2ConfigBase):
     enable_startup_entry: bool = Field(default=False)
 
     # Triple Barrier Configuration
-    stop_loss_pct: Decimal = Field(default=Decimal("0.02"), gt=0)
     trailing_stop_loss_pct: Decimal = Field(default=Decimal("0.01"), gt=0)
 
     # ADX Configuration
@@ -179,7 +178,6 @@ class DEMASTADXTokenStrategy(StrategyV2Base):
                         # For long: activation price is DEMA (where we expect price to reach)
                         activation_price_pct = abs(current_dema - mid_price) / mid_price
                         trailing_delta_pct = self.config.trailing_stop_loss_pct
-                        sl_pct = self.config.stop_loss_pct
 
                         trailing_stop = TrailingStop(
                             activation_price=Decimal(str(activation_price_pct)),
@@ -187,7 +185,6 @@ class DEMASTADXTokenStrategy(StrategyV2Base):
                         )
 
                         triple_barrier_config = TripleBarrierConfig(
-                            stop_loss=Decimal(str(sl_pct)),
                             trailing_stop=trailing_stop
                         )
                     else:  # Conditions 1 & 2: Default config with all barriers disabled
@@ -211,7 +208,6 @@ class DEMASTADXTokenStrategy(StrategyV2Base):
                         # For short: activation price is DEMA (where we expect price to reach)
                         activation_price_pct = abs(mid_price - current_dema) / mid_price
                         trailing_delta_pct = self.config.trailing_stop_loss_pct
-                        sl_pct = self.config.stop_loss_pct
 
                         trailing_stop = TrailingStop(
                             activation_price=Decimal(str(activation_price_pct)),
@@ -219,7 +215,6 @@ class DEMASTADXTokenStrategy(StrategyV2Base):
                         )
 
                         triple_barrier_config = TripleBarrierConfig(
-                            stop_loss=Decimal(str(sl_pct)),
                             trailing_stop=trailing_stop
                         )
                     else:  # Conditions 1 & 2: Default config with all barriers disabled

--- a/scripts/Dema_ST_ADX.py
+++ b/scripts/Dema_ST_ADX.py
@@ -428,7 +428,7 @@ class DEMASTADXTokenStrategy(StrategyV2Base):
         return signal, signal_source
 
     def _check_long_conditions(self, current_supertrend_direction, current_price, current_dema,
-                               adx_crossed_threshold, adx_above_threshold, prev_supertrend_direction) -> tuple[bool, bool, bool]:
+                               adx_crossed_threshold, adx_above_threshold, prev_supertrend_direction) -> tuple[bool, bool, bool, bool]:
         """Check all long entry conditions."""
         # Long Entry Conditions:
         # 1. ADX crosses threshold with established bullish trend: ST already positive + Price > DEMA + ADX crosses above threshold
@@ -455,7 +455,7 @@ class DEMASTADXTokenStrategy(StrategyV2Base):
         return long_condition_1, long_condition_2, long_condition_3, long_condition_4
 
     def _check_short_conditions(self, current_supertrend_direction, current_price, current_dema,
-                                adx_crossed_threshold, adx_above_threshold, prev_supertrend_direction) -> tuple[bool, bool, bool]:
+                                adx_crossed_threshold, adx_above_threshold, prev_supertrend_direction) -> tuple[bool, bool, bool, bool]:
         """Check all short entry conditions."""
         # Short Entry Conditions:
         # 1. ADX crosses threshold with established bearish trend: ST already negative + Price < DEMA + ADX crosses above threshold

--- a/scripts/sma_crossover_fixed.py
+++ b/scripts/sma_crossover_fixed.py
@@ -1,0 +1,463 @@
+import os
+from decimal import Decimal
+from typing import Dict, List, Optional
+
+from pydantic import Field, field_validator
+
+from hummingbot.connector.connector_base import ConnectorBase
+from hummingbot.core.clock import Clock
+from hummingbot.core.data_type.common import MarketDict, OrderType, PositionMode, PriceType, TradeType
+from hummingbot.data_feed.candles_feed.candles_factory import CandlesConfig
+from hummingbot.strategy.strategy_v2_base import StrategyV2Base, StrategyV2ConfigBase
+from hummingbot.strategy_v2.executors.position_executor.data_types import (
+    PositionExecutorConfig,
+    TrailingStop,
+    TripleBarrierConfig,
+)
+from hummingbot.strategy_v2.models.executor_actions import CreateExecutorAction, StopExecutorAction
+
+
+class SMAConfig(StrategyV2ConfigBase):
+    script_file_name: str = os.path.basename(__file__)
+    markets: MarketDict = MarketDict()
+    candles_config: List[CandlesConfig] = []
+    controllers_config: List[str] = []
+
+    # Exchange configuration
+    exchange: str = Field(default="hyperliquid_perpetual")
+    trading_pairs: List[str] = Field(default=["ETH-USD"])
+    candles_exchange: str = Field(default="binance_perpetual")
+    candles_pairs: List[str] = Field(default=["ETH-USDT"])
+    candles_interval: str = Field(default="5m")
+    candles_length: int = Field(default=50, gt=0)
+
+    # SMA Configuration
+    short_ma_length: int = Field(default=7, gt=0)
+    long_ma_length: int = Field(default=25, gt=0)
+
+    # ADX Configuration
+    adx_filter: bool = Field(default=False)
+    adx_threshold: int = Field(default=25, gt=0)
+    adx_length: int = Field(default=14, gt=0)
+
+    # Order Configuration
+    order_amount_quote: Decimal = Field(default=Decimal("100"), gt=0)
+    leverage: int = Field(default=5, gt=0)
+    position_mode: PositionMode = Field(default=PositionMode.ONEWAY)
+
+    # Triple Barrier Configuration
+    stop_loss: Optional[Decimal] = Field(default=None)
+    take_profit: Optional[Decimal] = Field(default=None)
+    time_limit: Optional[int] = Field(default=None)
+    trailing_stop_activation_price: Optional[Decimal] = Field(default=None)
+    trailing_stop_trailing_delta: Optional[Decimal] = Field(default=None)
+
+    @property
+    def triple_barrier_config(self) -> TripleBarrierConfig:
+        return TripleBarrierConfig(
+            stop_loss=self.stop_loss,
+            take_profit=self.take_profit,
+            time_limit=self.time_limit,
+            open_order_type=OrderType.MARKET,
+            take_profit_order_type=OrderType.LIMIT,
+            stop_loss_order_type=OrderType.MARKET,
+            time_limit_order_type=OrderType.MARKET,
+            trailing_stop=self.trailing_stop_activation_price is not None and self.trailing_stop_trailing_delta is not None and TrailingStop(
+                activation_price=self.trailing_stop_activation_price,
+                trailing_delta=self.trailing_stop_trailing_delta
+            ) or None
+        )
+
+    @field_validator('position_mode', mode="before")
+    @classmethod
+    def validate_position_mode(cls, v: str) -> PositionMode:
+        if isinstance(v, str) and v.upper() in PositionMode.__members__:
+            return PositionMode[v.upper()]
+        elif isinstance(v, PositionMode):
+            return v
+        raise ValueError(f"Invalid position mode: {v}. Valid options are: {', '.join(PositionMode.__members__)}")
+
+    @field_validator('trading_pairs', mode="before")
+    @classmethod
+    def validate_trading_pairs(cls, v) -> List[str]:
+        if isinstance(v, str):
+            return [pair.strip() for pair in v.split(',')]
+        return v
+
+    @field_validator('candles_pairs', mode="before")
+    @classmethod
+    def validate_candles_pairs(cls, v) -> List[str]:
+        if isinstance(v, str):
+            return [pair.strip() for pair in v.split(',')]
+        return v
+
+
+class SMAStrategy(StrategyV2Base):
+    """
+    Simple Moving Average (SMA) Crossover Strategy with multiple trading pairs support.
+    Opens long when short MA crosses above long MA.
+    Opens short when short MA crosses below long MA.
+
+    FIXED VERSION: Properly handles position state transitions and prevents
+    opening new positions before existing ones are fully closed.
+    """
+
+    account_config_set = False
+
+    @classmethod
+    def init_markets(cls, config: SMAConfig):
+        cls.markets = {config.exchange: set(config.trading_pairs)}
+
+    def __init__(self, connectors: Dict[str, ConnectorBase], config: SMAConfig):
+        self.max_records = max(config.short_ma_length, config.long_ma_length, config.candles_length, config.adx_length) + 10
+
+        if len(config.candles_config) == 0:
+            for candles_pair in config.candles_pairs:
+                config.candles_config.append(CandlesConfig(
+                    connector=config.candles_exchange,
+                    trading_pair=candles_pair,
+                    interval=config.candles_interval,
+                    max_records=self.max_records
+                ))
+
+        super().__init__(connectors, config)
+        self.config = config
+
+        # Track current and previous MA values per trading pair
+        self.current_short_ma = {}
+        self.current_long_ma = {}
+        self.prev_short_ma = {}
+        self.prev_long_ma = {}
+        self.current_price = {}
+        self.last_signal = {}
+
+        # Track ADX values per trading pair
+        self.current_adx = {}
+
+        # Track positions being closed to prevent new positions until fully closed
+        self.closing_positions = {}
+
+    def start(self, clock: Clock, timestamp: float) -> None:
+        """
+        Start the strategy.
+        :param clock: Clock to use.
+        :param timestamp: Current time.
+        """
+        self._last_timestamp = timestamp
+        self.apply_initial_setting()
+
+    def create_actions_proposal(self) -> List[CreateExecutorAction]:
+        create_actions = []
+
+        # Check signals for each trading pair
+        for i, trading_pair in enumerate(self.config.trading_pairs):
+            candles_pair = self.config.candles_pairs[i]
+            signal = self.get_signal(self.config.candles_exchange, candles_pair)
+
+            if signal is None or signal == 0:
+                continue
+
+            # Check ADX threshold
+            current_adx = self.current_adx.get(candles_pair, 0)
+            if self.config.adx_filter and current_adx < self.config.adx_threshold:
+                continue
+
+            active_longs, active_shorts = self.get_active_executors_by_side(
+                self.config.exchange, trading_pair
+            )
+
+            # Check if we're currently closing a position for this pair
+            if trading_pair in self.closing_positions:
+                # Skip creating new positions until the close is complete
+                continue
+
+            # Check if we have any executors that are not fully terminated
+            all_executors = self.get_all_executors()
+            non_terminated_executors = [e for e in all_executors
+                                        if e.trading_pair == trading_pair
+                                        and not e.is_done]  # Not yet TERMINATED
+
+            if non_terminated_executors:
+                # Skip creating new positions if executors are still shutting down
+                continue
+
+            mid_price = self.market_data_provider.get_price_by_type(
+                self.config.exchange,
+                trading_pair,
+                PriceType.MidPrice
+            )
+
+            # Open long position on bullish crossover
+            # Check that there are no active positions at all
+            if signal == 1 and len(active_longs) == 0 and len(active_shorts) == 0:
+                create_actions.append(CreateExecutorAction(
+                    executor_config=PositionExecutorConfig(
+                        timestamp=self.current_timestamp,
+                        connector_name=self.config.exchange,
+                        trading_pair=trading_pair,
+                        side=TradeType.BUY,
+                        entry_price=mid_price,
+                        amount=self.config.order_amount_quote / mid_price,
+                        triple_barrier_config=self.config.triple_barrier_config,
+                        leverage=self.config.leverage
+                    )
+                ))
+
+            # Open short position on bearish crossover
+            # Check that there are no active positions at all
+            elif signal == -1 and len(active_shorts) == 0 and len(active_longs) == 0:
+                create_actions.append(CreateExecutorAction(
+                    executor_config=PositionExecutorConfig(
+                        timestamp=self.current_timestamp,
+                        connector_name=self.config.exchange,
+                        trading_pair=trading_pair,
+                        side=TradeType.SELL,
+                        entry_price=mid_price,
+                        amount=self.config.order_amount_quote / mid_price,
+                        triple_barrier_config=self.config.triple_barrier_config,
+                        leverage=self.config.leverage
+                    )
+                ))
+
+        return create_actions
+
+    def stop_actions_proposal(self) -> List[StopExecutorAction]:
+        stop_actions = []
+
+        # Check signals for each trading pair
+        for i, trading_pair in enumerate(self.config.trading_pairs):
+            candles_pair = self.config.candles_pairs[i]
+            signal = self.get_signal(self.config.candles_exchange, candles_pair)
+
+            if signal is None:
+                continue
+
+            active_longs, active_shorts = self.get_active_executors_by_side(
+                self.config.exchange, trading_pair
+            )
+
+            # Close long positions on bearish crossover
+            if signal == -1 and len(active_longs) > 0:
+                # Mark that we're closing positions for this pair
+                self.closing_positions[trading_pair] = True
+                stop_actions.extend([
+                    StopExecutorAction(
+                        controller_id=e.controller_id or "main",
+                        executor_id=e.id
+                    ) for e in active_longs
+                ])
+
+            # Close short positions on bullish crossover
+            elif signal == 1 and len(active_shorts) > 0:
+                # Mark that we're closing positions for this pair
+                self.closing_positions[trading_pair] = True
+                stop_actions.extend([
+                    StopExecutorAction(
+                        controller_id=e.controller_id or "main",
+                        executor_id=e.id
+                    ) for e in active_shorts
+                ])
+
+            # Clear closing flag if no active positions remain
+            if (trading_pair in self.closing_positions and
+                    len(active_longs) == 0 and len(active_shorts) == 0):
+                del self.closing_positions[trading_pair]
+
+        return stop_actions
+
+    def get_active_executors_by_side(self, connector_name: str, trading_pair: str):
+        active_executors = self.filter_executors(
+            executors=self.get_all_executors(),
+            filter_func=lambda e: e.connector_name == connector_name and e.trading_pair == trading_pair and e.is_active
+        )
+        active_longs = [e for e in active_executors if e.side == TradeType.BUY]
+        active_shorts = [e for e in active_executors if e.side == TradeType.SELL]
+        return active_longs, active_shorts
+
+    def get_signal(self, connector_name: str, trading_pair: str) -> Optional[int]:
+        candles = self.market_data_provider.get_candles_df(
+            connector_name,
+            trading_pair,
+            self.config.candles_interval,
+            self.max_records
+        )
+
+        if candles is None or candles.empty or len(candles) < self.config.long_ma_length + 2:
+            return None
+
+        # Calculate SMAs
+        candles.ta.sma(length=self.config.short_ma_length, append=True)
+        candles.ta.sma(length=self.config.long_ma_length, append=True)
+
+        # Calculate ADX
+        candles.ta.adx(length=self.config.adx_length, append=True)
+
+        # We need at least 2 candles to detect signals
+        if len(candles) < 2:
+            return None
+
+        # Use current candle for signal detection (more reactive but may change)
+        # Index -2: Previous candle (fully closed)
+        # Index -1: Current candle (incomplete, used for signals)
+        # WARNING: Signals may change as the current candle develops
+
+        short_ma_col = f"SMA_{self.config.short_ma_length}"
+        long_ma_col = f"SMA_{self.config.long_ma_length}"
+
+        # Get MA values including current candle
+        short_ma_prev = candles[short_ma_col].iloc[-2]  # Previous closed candle
+        long_ma_prev = candles[long_ma_col].iloc[-2]    # Previous closed candle
+
+        short_ma_current = candles[short_ma_col].iloc[-1]  # Current candle (incomplete)
+        long_ma_current = candles[long_ma_col].iloc[-1]    # Current candle (incomplete)
+
+        # Store current values for display purposes
+        self.prev_short_ma[trading_pair] = short_ma_prev
+        self.prev_long_ma[trading_pair] = long_ma_prev
+        self.current_short_ma[trading_pair] = short_ma_current
+        self.current_long_ma[trading_pair] = long_ma_current
+        self.current_price[trading_pair] = candles["close"].iloc[-1]
+
+        # Store ADX value
+        adx_col = f"ADX_{self.config.adx_length}"
+        if adx_col in candles.columns:
+            self.current_adx[trading_pair] = candles[adx_col].iloc[-1]
+        else:
+            self.current_adx[trading_pair] = 0
+
+        # Detect signals using current candle (may change as candle develops)
+        signal = 0
+
+        # Bullish signal: Short MA crosses above long MA
+        # Previous candle: Short MA was below or equal to long MA
+        # Current candle: Short MA is now above long MA
+        if (short_ma_prev <= long_ma_prev and      # Was below or equal in previous candle
+                short_ma_current > long_ma_current):    # Now above in current candle
+            signal = 1
+
+        # Bearish signal: Short MA crosses below long MA
+        # Previous candle: Short MA was above or equal to long MA
+        # Current candle: Short MA is now below long MA
+        elif (short_ma_prev >= long_ma_prev and     # Was above or equal in previous candle
+              short_ma_current < long_ma_current):   # Now below in current candle
+            signal = -1
+
+        self.last_signal[trading_pair] = signal
+        return signal
+
+    def apply_initial_setting(self):
+        if not self.account_config_set:
+            for connector_name, connector in self.connectors.items():
+                if self.is_perpetual(connector_name):
+                    connector.set_position_mode(self.config.position_mode)
+                    for trading_pair in self.config.trading_pairs:
+                        connector.set_leverage(trading_pair, self.config.leverage)
+            self.account_config_set = True
+
+    def format_status(self) -> str:
+        if not self.ready_to_trade:
+            return "Market connectors are not ready."
+
+        lines = []
+
+        # Create market overview
+        lines.extend(["", "  Market Overview:"])
+
+        # Header
+        header = f"  {'Symbol':<15} {'Price':<10} {'MA' + str(self.config.short_ma_length):<10} {'MA' + str(self.config.long_ma_length):<10} {'ADX':<8} {'Trend':<15} {'Signal':<10} {'Longs':<6} {'Shorts':<6} {'Status':<15}"
+        separator = f"  {'-' * 15} {'-' * 10} {'-' * 10} {'-' * 10} {'-' * 8} {'-' * 15} {'-' * 10} {'-' * 6} {'-' * 6} {'-' * 15}"
+        lines.extend([header, separator])
+
+        # Display each trading pair
+        for i, candles_pair in enumerate(self.config.candles_pairs):
+            price = self.current_price.get(candles_pair, 0)
+            short_ma = self.current_short_ma.get(candles_pair, 0)
+            long_ma = self.current_long_ma.get(candles_pair, 0)
+            adx = self.current_adx.get(candles_pair, 0)
+            signal = self.last_signal.get(candles_pair, 0)
+
+            # Determine trend
+            if short_ma > 0 and long_ma > 0:
+                if short_ma > long_ma:
+                    trend = "BULLISH"
+                else:
+                    trend = "BEARISH"
+            else:
+                trend = "N/A"
+
+            # Format signal
+            signal_text = "BUY" if signal == 1 else "SELL" if signal == -1 else "NONE"
+
+            # Get active positions
+            if i < len(self.config.trading_pairs):
+                actual_trading_pair = self.config.trading_pairs[i]
+                active_longs, active_shorts = self.get_active_executors_by_side(
+                    self.config.exchange, actual_trading_pair
+                )
+
+                # Check if we're closing positions
+                status = "CLOSING" if actual_trading_pair in self.closing_positions else "NORMAL"
+            else:
+                active_longs, active_shorts = [], []
+                status = "N/A"
+
+            # Format row
+            symbol = candles_pair.replace('-', '/')
+            row = f"  {symbol:<15} {price:<10.2f} {short_ma:<10.2f} {long_ma:<10.2f} {adx:<8.2f} {trend:<15} {signal_text:<10} {len(active_longs):<6} {len(active_shorts):<6} {status:<15}"
+            lines.append(row)
+
+        # Add configuration info
+        lines.extend([
+            "",
+            f"  Config: MA{self.config.short_ma_length} / MA{self.config.long_ma_length} | "
+            f"ADX Filtering on: {self.config.adx_filter} | "
+            f"ADX Threshold: {self.config.adx_threshold} | "
+            f"Interval: {self.config.candles_interval} | "
+            f"SL: {self.config.stop_loss:.1%} | TP: {self.config.take_profit:.1%}"
+        ])
+
+        # Display active positions with details
+        active_executors = self.filter_executors(
+            executors=self.get_all_executors(),
+            filter_func=lambda e: e.is_active
+        )
+
+        if active_executors:
+            lines.extend(["", "  Active Positions:"])
+
+            # Position table header
+            pos_header = f"  {'Symbol':<12} {'Side':<5} {'Entry':<10} {'Current':<10} {'PnL USD':<10} {'PnL %':<8} {'Size':<10}"
+            pos_separator = f"  {'-' * 12} {'-' * 5} {'-' * 10} {'-' * 10} {'-' * 10} {'-' * 8} {'-' * 10}"
+            lines.extend([pos_header, pos_separator])
+
+            for executor in active_executors:
+                symbol = executor.trading_pair
+                side = "LONG" if executor.side == TradeType.BUY else "SHORT"
+
+                # Get entry price from custom_info
+                entry_price = executor.custom_info.get("current_position_average_price", Decimal("0"))
+                entry = f"{entry_price:.2f}" if entry_price > 0 else "N/A"
+
+                # Get current price from cached price or fetch it
+                if symbol in self.current_price:
+                    current = f"{self.current_price[symbol]:.2f}"
+                else:
+                    # If we don't have cached price, get it from the corresponding candles pair
+                    for i, trading_pair in enumerate(self.config.trading_pairs):
+                        if trading_pair == symbol and i < len(self.config.candles_pairs):
+                            candles_pair = self.config.candles_pairs[i]
+                            current = f"{self.current_price.get(candles_pair, 0):.2f}"
+                            break
+                    else:
+                        current = "N/A"
+
+                pnl_usd = f"{executor.net_pnl_quote:+.2f}"
+                pnl_pct = f"{executor.net_pnl_pct * 100:+.2f}%"
+                size = f"{executor.filled_amount_quote:.2f}"
+
+                row = f"  {symbol:<12} {side:<5} {entry:<10} {current:<10} {pnl_usd:<10} {pnl_pct:<8} {size:<10}"
+                lines.append(row)
+        else:
+            lines.extend(["", "  No active positions"])
+
+        return "\n".join(lines)


### PR DESCRIPTION
## Summary
- Add new long and short entry condition (condition 3) that triggers when SuperTrend is positive/negative, ADX is above threshold, but price is on opposite side of DEMA
- Implement trailing stop loss that activates when price reaches DEMA for condition 3 trades
- Refactor signal generation logic into separate methods for better maintainability
- Track signal source to enable different risk management per entry condition

## Test plan
- [ ] Test condition 3 long entries: ST green, ADX > threshold, price < DEMA
- [ ] Test condition 3 short entries: ST red, ADX > threshold, price > DEMA  
- [ ] Verify trailing stop activates at DEMA price level
- [ ] Confirm conditions 1 & 2 still work with default triple barrier config
- [ ] Test ADX directional filter still applies correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced trading signals now track the specific condition that triggered each signal, providing more detailed insights.
  * Introduced a new trailing stop activation condition for both long and short entries, offering improved risk management.
  * Dynamic stop-loss configuration: trailing stops are automatically set when triggered by the new condition, while other entries disable triple barriers.

* **Refactor**
  * Signal logic has been modularized for improved clarity and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->